### PR TITLE
Due to some wrong order of operations some times a peer connection is…

### DIFF
--- a/src/net/WebRTC/RTCPeerConnection.cs
+++ b/src/net/WebRTC/RTCPeerConnection.cs
@@ -1744,7 +1744,9 @@ namespace SIPSorcery.Net
 
                 if (sctp == null || sctp.state != RTCSctpTransportState.Connected)
                 {
-                    throw new ApplicationException("No SCTP transport is available.");
+                    dataChannels.AddPendingChannel(channel);
+                    return channel;
+                    //throw new ApplicationException("No SCTP transport is available.");
                 }
                 else
                 {


### PR DESCRIPTION
… connected, but sctp is null. Added data channel to pending fixes this issue.